### PR TITLE
Bug issue4 move add receipt image button

### DIFF
--- a/src/web/src/components/expenses/Expense.js
+++ b/src/web/src/components/expenses/Expense.js
@@ -12,8 +12,9 @@ const useStyles = makeStyles({
     alignItems: 'center',
     gap: '1em'
   },
-  expenseForm: {
-    width: '100vw'
+
+  imgTable: {
+    width: 'calc(100vw - 100px)'
   }
 });
 
@@ -30,7 +31,9 @@ const Expense = () => {
   };
   return (
     <div className={classes.container}>
-      <ImgTable />
+      <div className={classes.imgTable}>
+        <ImgTable />
+      </div>
       <Formik initialValues={initialValues}>
         {({ values, handleChange, setFieldValue }) => (
           <Form className={classes.expenseForm}>

--- a/src/web/src/components/expenses/addReceiptImg/AddReceiptButton.js
+++ b/src/web/src/components/expenses/addReceiptImg/AddReceiptButton.js
@@ -23,11 +23,11 @@ const AddReceiptButton = () => {
         anchorEl={anchorEl}
         onClose={handleClose}
         anchorOrigin={{
-          vertical: 'bottom',
+          vertical: 'top',
           horizontal: 'center'
         }}
         transformOrigin={{
-          vertical: 'top',
+          vertical: 'bottom',
           horizontal: 'right'
         }}
       >

--- a/src/web/src/components/expenses/expenseForms/ImgTable.js
+++ b/src/web/src/components/expenses/expenseForms/ImgTable.js
@@ -8,12 +8,18 @@ import Paper from '@mui/material/Paper';
 import { makeStyles } from '@mui/styles';
 import { styled } from '@mui/system';
 import { Card, CardContent, CardMedia, Typography } from '@mui/material';
+import AddReceiptButton from '../../expenses/addReceiptImg/AddReceiptButton';
 
 const useStyles = makeStyles({
   tableContainer: {
-    width: 'calc(100vw - 40px)',
+    width: 'calc(100vw - 100px)',
     border: 'solid 1px',
     margin: '20px 0'
+  },
+  addReceiptButton: {
+    display: 'flex',
+    width: 'calc(100vw - 100px)',
+    justifyContent: 'flex-end'
   }
 });
 
@@ -35,29 +41,34 @@ const datas = [
 const ImgTable = () => {
   const classes = useStyles();
   return (
-    <TableContainer className={classes.tableContainer} component={Paper}>
-      <Table aria-label="simple table">
-        <TableBody>
-          <TableRow>
-            {datas.map((data, index) => (
-              <TableCell key={index}>
-                <StyledCard>
-                  <CardMedia
-                    component="img"
-                    sx={{ objectFit: 'cover' }}
-                    image={data}
-                    alt="Expense Img"
-                  />
-                  <CardContent sx={{ textAlign: 'center', fontFamily: 'Roboto' }}>
-                    <Typography variant="body">Receipt</Typography>
-                  </CardContent>
-                </StyledCard>
-              </TableCell>
-            ))}
-          </TableRow>
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <>
+      <TableContainer className={classes.tableContainer} component={Paper}>
+        <Table aria-label="simple table">
+          <TableBody>
+            <TableRow>
+              {datas.map((data, index) => (
+                <TableCell key={index}>
+                  <StyledCard>
+                    <CardMedia
+                      component="img"
+                      sx={{ objectFit: 'cover' }}
+                      image={data}
+                      alt="Expense Img"
+                    />
+                    <CardContent sx={{ textAlign: 'center', fontFamily: 'Roboto' }}>
+                      <Typography variant="body">Receipt</Typography>
+                    </CardContent>
+                  </StyledCard>
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <div className={classes.addReceiptButton}>
+        <AddReceiptButton />
+      </div>
+    </>
   );
 };
 

--- a/src/web/src/components/utilBar/UtilBar.js
+++ b/src/web/src/components/utilBar/UtilBar.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import SortButton from './sortButton/SortButton';
 import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
-import { Button, IconButton, Tooltip } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import { useHistory, useLocation } from 'react-router-dom';
 import SearchBar from './searchBar/SearchBar';
-import AddReceiptButton from '../expenses/addReceiptImg/AddReceiptButton';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -31,12 +30,11 @@ const UtilBar = () => {
     if (pathname.match('/expense/w*')) {
       return (
         <>
-          <AddReceiptButton />
           <Tooltip title="Search" placement="left">
             <IconButton onClick={() => history.push('/search')}>
               <SearchRoundedIcon />
             </IconButton>
-          </Tooltip>{' '}
+          </Tooltip>
         </>
       );
     }


### PR DESCRIPTION
## Issue This PR Addresses

- Fixes #4 
- UI Improvement

## Description
Moves the add receipt image below and repositions popover to be on the top center wrt to the "Add receipt image" button

![image](https://user-images.githubusercontent.com/29209451/169677306-bf29abf1-8fa7-4c6f-9123-3e87e6feea8f.png)
